### PR TITLE
Stop include example code in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">= 4.0.0"
   },
   "scripts": {
-    "codecov": "istanbul cover _mocha -- --reporter spec -i -g 'External Interop' --slow 1000 --timeout 5000 && codecov",
+    "codecov": "istanbul cover -x '**/example/**' -x '**/interop/**' _mocha -- --reporter spec -i -g 'External Interop' --slow 1000 --timeout 5000 && codecov",
     "doc": "jsdoc -c jsdoc.json",
     "interop-test": "istanbul test _mocha -- --reporter spec -g 'External Interop'",
     "install-go-interop": "./interop/go_interop_agent.js",


### PR DESCRIPTION
- stops including the example and interop dirs in the coverage report
