### PR TITLE
Add requireProto to simplify proto loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ function sayHello(request, response) {
  * sample server port
  */
 function main() {
-  var hellopb = protobuf.loadProto(path.join(__dirname, 'helloworld.proto'));
+  var hellopb = protobuf.requireProto('helloworld');
   var app = new app.RpcApp(hellopb.ex.grpc.Greeter.server);
   app.register('/ex.grpc/SayHello', sayHello);
 
@@ -173,7 +173,7 @@ var buildClient = require('dorusu/client').buildClient;
 var protobuf = require('dorusu/protobuf');
 
 function main() {
-  var hellopb = protobuf.loadProto(path.join(__dirname, 'helloworld.proto'));
+  var hellopb = protobuf.requireProto('helloworld');
   var Ctor = buildClient(hellopb.ex.grpc.Greeter.client);
   var client = new Ctor({
     host: 'localhost',

--- a/example/math_client.js
+++ b/example/math_client.js
@@ -65,7 +65,6 @@ var bunyan = require('bunyan');
 var expect = require('chai').expect;
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
-var path = require('path');
 var dorusu = require('../lib');
 var secureOptions = require('../test/util').secureClientOptions;
 
@@ -240,7 +239,7 @@ var main = function main() {
   } else {
     _.merge(opts, insecureOptions);
   }
-  var mathpb = dorusu.pb.loadProto(path.join(__dirname, 'math.proto'));
+  var mathpb = dorusu.pb.requireProto('./math', require);
   var Ctor = dorusu.buildClient(mathpb.math.Math.client);
   var client = new Ctor(opts);
   async.series([

--- a/example/math_server.js
+++ b/example/math_server.js
@@ -63,7 +63,6 @@ var app = require('../lib/app');
 var bunyan = require('bunyan');
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
-var path = require('path');
 var dorusu = require('../lib');
 var secureOptions = require('../test/util').secureOptions;
 
@@ -183,7 +182,7 @@ var parseArgs = function parseArgs() {
  * @returns {app.RpcApp} providing the math service implementation
  */
 var buildApp = exports.buildApp = function buildApp() {
-  var mathpb = dorusu.pb.loadProto(path.join(__dirname, 'math.proto'));
+  var mathpb = dorusu.pb.requireProto('./math', require);
   var a = new app.RpcApp(mathpb.math.Math.server);
   a.register('/math.Math/DivMany', mathDiv);
   a.register('/math.Math/Div', mathDiv);

--- a/interop/interop_client.js
+++ b/interop/interop_client.js
@@ -68,7 +68,6 @@ chai.use(require('dirty-chai'));
 var expect = chai.expect;
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
-var path = require('path');
 var dorusu = require('../lib');
 var secureOptions = require('../example/certs').clientOptions;
 
@@ -759,7 +758,7 @@ var main = function main() {
       rejectUnauthorized: false
     });
   }
-  var testpb = dorusu.pb.loadProto(path.join(__dirname, 'test.proto'));
+  var testpb = dorusu.pb.requireProto('./test', require);
   var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
 
   if (_.has(exports.withoutAuthTests, args.test_case)) {

--- a/interop/interop_server.js
+++ b/interop/interop_server.js
@@ -67,8 +67,6 @@ var bunyan = require('bunyan');
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
 var dorusu = require('../lib');
-var path = require('path');
-var protobuf = dorusu.pb;
 
 var secureOptions = require('../example/certs').serverOptions;
 
@@ -174,7 +172,7 @@ function streamingOutputCall(request, response) {
  * @returns {app.RpcApp} providing the interop service implementation
  */
 var buildApp = exports.buildApp = function buildApp() {
-  var testpb = protobuf.loadProto(path.join(__dirname, 'test.proto'));
+  var testpb = dorusu.pb.requireProto('./test', require);
   var a = new app.RpcApp(testpb.grpc.testing.TestService.server);
   a.register('/grpc.testing.TestService/EmptyCall', emptyCall);
   a.register('/grpc.testing.TestService/UnaryCall', unaryCall);

--- a/lib/protobuf.js
+++ b/lib/protobuf.js
@@ -33,7 +33,7 @@
 'use strict';
 
 var _ = require('lodash');
-var app = require('./app.js');
+var app = require('./app');
 
 var ProtoBuf = require('protobufjs');
 
@@ -200,6 +200,30 @@ exports.loadProto = function loadProto(path, format) {
   }
 
   return loadObject(builder.ns);
+};
+
+/**
+ * Load a proto peer object a proto file using standard node module resolution
+ * order.
+ *
+ * id can omit the usual '.proto' extension, i.e, both
+ * require('my_service.proto') and require('my_service')
+ *
+ * opt_require is usually only necessary when the 'id' is a local relative
+ * path.  it should be unnecessary for protos in imported packages like
+ * node_modules.
+ *
+ * @param {string} id the node 'id' of the proto file
+ * @param {function} opt_require the require function of the module that
+ *   loads the id.
+ * @returns {Object<string, *>} a proto peer object
+ */
+exports.requireProto = function requireProto(id, opt_require) {
+  var our_require = opt_require || require;
+  if (!id.endsWith('.proto')) {
+    id += '.proto';
+  }
+  return exports.loadProto(our_require.resolve(id));
 };
 
 exports.loadObject = loadObject;

--- a/test/go_external_interop_test.js
+++ b/test/go_external_interop_test.js
@@ -42,7 +42,6 @@ var interopClient = require('../interop/interop_client');
 var listenOnFreePort = require('./util').listenOnFreePort;
 var nextAvailablePort = require('./util').nextAvailablePort;
 var dorusu = require('../lib');
-var path = require('path');
 
 var GoAgent = require('../interop/go_interop_agent').GoAgent;
 
@@ -54,14 +53,12 @@ var testClientOptions = {
 };
 testClientOptions.secure.rejectUnauthorized = false;
 
-var TEST_PROTO_PATH = path.join(__dirname, '../interop/test.proto');
-
 describe('External Interop Nodejs/Go', function() {
   /* Adjust the test timeout/duration; Go is spawned in a child proc */
   this.slow(5000);
   this.timeout(8000);
 
-  var testpb = dorusu.pb.loadProto(TEST_PROTO_PATH);
+  var testpb = dorusu.pb.requireProto('../interop/test');
   var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
   var theClient, agent;
   _.forEach(testClientOptions, function(serverOpts, connType) {

--- a/test/interop_client_test.js
+++ b/test/interop_client_test.js
@@ -41,7 +41,6 @@ var insecureOptions = require('./util').insecureOptions;
 var interopClient = require('../interop/interop_client');
 var listenOnFreePort = require('./util').listenOnFreePort;
 var dorusu = require('../lib');
-var path = require('path');
 var secureOptions = require('../example/certs').options;
 
 http2.globalAgent = new http2.Agent({ log: clientLog });
@@ -54,7 +53,8 @@ var testOptions = {
 };
 
 describe('Interop Client', function() {
-  var testpb = dorusu.pb.loadProto(path.join(__dirname, '../interop/test.proto'));
+  var testpb = dorusu.pb.requireProto('../interop/test');
+
   var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
   var theClient, server, serverAddr;
   _.forEach(testOptions, function(serverOpts, connType) {

--- a/test/math_client_test.js
+++ b/test/math_client_test.js
@@ -41,12 +41,11 @@ var insecureOptions = require('./util').insecureOptions;
 var listenOnFreePort = require('./util').listenOnFreePort;
 var mathClient = require('../example/math_client');
 var dorusu = require('../lib');
-var path = require('path');
 var secureOptions = require('../example/certs').options;
 
 http2.globalAgent = new http2.Agent({ log: clientLog });
 
-var mathpb = dorusu.pb.loadProto(path.join(__dirname, '../example/math.proto'));
+var mathpb = dorusu.pb.requireProto('../example/math');
 var mathClientCls = dorusu.buildClient(mathpb.math.Math.client);
 var testOptions = {
   secure: secureOptions,

--- a/test/protobuf.js
+++ b/test/protobuf.js
@@ -72,9 +72,9 @@ describe('`function loadProto(path, [format])`', function() {
     };
     expect(shouldThrow).to.throw(Error);
   });
-  it('should load service defined in the proto', function() {
-    var testProto = protobuf.loadProto(fixturePath('test_service.proto'));
-    _.forEach(['client', 'server'], function(side) {
+  _.forEach(['client', 'server'], function(side) {
+    it('should load a ' + side + ' defined in the proto file', function() {
+      var testProto = protobuf.loadProto(fixturePath('test_service.proto'));
       var got = testProto.TestService[side];
       expect(got).to.be.an.instanceof(app.Service);
       expect(got.name).to.eql('TestService');
@@ -82,15 +82,57 @@ describe('`function loadProto(path, [format])`', function() {
       expect(methods).to.eql(['Unary', 'ClientStream', 'ServerStream',
                               'BidiStream']);
     });
-  });
-  it('should load service defined in a proto with a package', function() {
-    var mathProto = protobuf.loadProto(examplePath('math.proto'));
-    _.forEach(['client', 'server'], function(side) {
+    it('should load a ' + side + ' defined with a package', function() {
+      var mathProto = protobuf.loadProto(examplePath('math.proto'));
       var got = mathProto.math.Math[side];
       expect(got).to.be.an.instanceof(app.Service);
       expect(got.name).to.eql('math.Math');
       var methods = _.map(got.methods, function(m) { return m.name; });
       expect(methods).to.eql(['Div', 'DivMany', 'Fib', 'Sum']);
+    });
+  });
+});
+
+describe('`function requireProto(path, [format])`', function() {
+  var absolutePath = fixturePath('test_service');
+  describe('when using an absolute path', function()  {
+    it('should require the proto file without an extension', function() {
+      var isOK = function isOK() {
+        protobuf.requireProto(absolutePath);
+      };
+      expect(isOK).to.not.throw(Error);
+    });
+    it('should require the proto file with an extension', function() {
+      var isOK = function isOK() {
+        protobuf.requireProto(absolutePath + '.proto');
+      };
+      expect(isOK).to.not.throw(Error);
+    });
+  });
+  var localPath = './fixtures/test_service';
+  describe('when using a relative path', function()  {
+    it('should require the proto file without an extension', function() {
+      var isOK = function isOK() {
+        protobuf.requireProto(localPath, require);
+      };
+      expect(isOK).to.not.throw(Error);
+    });
+    it('should require the proto file with an extension', function() {
+      var isOK = function isOK() {
+        protobuf.requireProto(localPath + '.proto', require);
+      };
+      expect(isOK).to.not.throw(Error);
+    });
+  });
+  _.forEach(['client', 'server'], function(side) {
+    it('should require ' + side + ' defined in the proto', function() {
+      var testProto = protobuf.requireProto(localPath, require);
+      var got = testProto.TestService[side];
+      expect(got).to.be.an.instanceof(app.Service);
+      expect(got.name).to.eql('TestService');
+      var methods = _.map(got.methods, function(m) { return m.name; });
+      expect(methods).to.eql(['Unary', 'ClientStream', 'ServerStream',
+                              'BidiStream']);
     });
   });
 });


### PR DESCRIPTION
Add requireProto which loads protos using node's simple [module loading](https://nodejs.org/api/modules.html#modules_all_together) system.

This means that services can be delivered as proto files.
