### PR TITLE
Simplify construction from protos

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ message HelloReply {
 
 ```javascript
 
-var app = require('dorusu/app');
 var protobuf = require('dorusu/protobuf');
 var server = require('dorusu/server');
 
@@ -150,8 +149,8 @@ function sayHello(request, response) {
  * sample server port
  */
 function main() {
-  var hellopb = protobuf.requireProto('helloworld');
-  var app = new app.RpcApp(hellopb.ex.grpc.Greeter.server);
+  var hellopb = protobuf.requireProto('./helloworld', require);
+  var app = hellopb.ex.grpc.Greeter.serverApp;
   app.register('/ex.grpc/SayHello', sayHello);
 
   /* server.raw.CreateServer is insecure, server.createServer is alway secure */
@@ -169,15 +168,14 @@ main();
 ### Access greetings with a client: helloworld_client.js
 
 ```javascript
-var buildClient = require('dorusu/client').buildClient;
 var protobuf = require('dorusu/protobuf');
 
 function main() {
-  var hellopb = protobuf.requireProto('helloworld');
-  var Ctor = buildClient(hellopb.ex.grpc.Greeter.client);
-  var client = new Ctor({
+  var hellopb = protobuf.requireProto('./helloworld', require);
+  /* <package>.Client.raw is insecure, <package>.Client is alway secure */
+  var GreeterClient = hellopb.ex.grpc.Greeter.Client.raw;
+  var client = new GreeterClient({
     host: 'localhost',
-    plain: true,  /* connections are secure by default */
     port: 50051,
     protocol: 'http:'
   });

--- a/example/math_client.js
+++ b/example/math_client.js
@@ -240,8 +240,7 @@ var main = function main() {
     _.merge(opts, insecureOptions);
   }
   var mathpb = dorusu.pb.requireProto('./math', require);
-  var Ctor = dorusu.buildClient(mathpb.math.Math.client);
-  var client = new Ctor(opts);
+  var client = new mathpb.math.Math.Client(opts);
   async.series([
     doOkDiv.bind(null, client),
     doBadDiv.bind(null, client),

--- a/example/math_server.js
+++ b/example/math_server.js
@@ -59,7 +59,6 @@
  */
 
 var _ = require('lodash');
-var app = require('../lib/app');
 var bunyan = require('bunyan');
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
@@ -182,8 +181,8 @@ var parseArgs = function parseArgs() {
  * @returns {app.RpcApp} providing the math service implementation
  */
 var buildApp = exports.buildApp = function buildApp() {
-  var mathpb = dorusu.pb.requireProto('./math', require);
-  var a = new app.RpcApp(mathpb.math.Math.server);
+  var mathSvc = dorusu.pb.requireProto('./math', require).math.Math;
+  var a = mathSvc.serverApp;
   a.register('/math.Math/DivMany', mathDiv);
   a.register('/math.Math/Div', mathDiv);
   a.register('/math.Math/Fib', mathFib);

--- a/interop/interop_client.js
+++ b/interop/interop_client.js
@@ -759,17 +759,18 @@ var main = function main() {
     });
   }
   var testpb = dorusu.pb.requireProto('./test', require);
-  var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
+  var TestServiceClient = testpb.grpc.testing.TestService.Client;
 
   if (_.has(exports.withoutAuthTests, args.test_case)) {
-    var client = new Ctor(opts);
+    var client = new TestServiceClient(opts);
     async.series([
       exports.withoutAuthTests[args.test_case].bind(null, client),
       process.exit.bind(null, 0)  /* TODO enable client's to be closed */
     ]);
   } else if (_.has(exports.withAuthTests, args.test_case)) {
     async.series([
-      exports.withAuthTests[args.test_case].bind(null, Ctor, opts, args),
+      exports.withAuthTests[args.test_case].bind(
+        null, TestServiceClient, opts, args),
       process.exit.bind(null, 0)  /* TODO enable client's to be closed */
     ]);
   }

--- a/interop/interop_server.js
+++ b/interop/interop_server.js
@@ -62,7 +62,6 @@
  */
 
 var _ = require('lodash');
-var app = require('../lib/app');
 var bunyan = require('bunyan');
 var http2 = require('http2');
 var insecureOptions = require('../test/util').insecureOptions;
@@ -172,8 +171,8 @@ function streamingOutputCall(request, response) {
  * @returns {app.RpcApp} providing the interop service implementation
  */
 var buildApp = exports.buildApp = function buildApp() {
-  var testpb = dorusu.pb.requireProto('./test', require);
-  var a = new app.RpcApp(testpb.grpc.testing.TestService.server);
+  var svc = dorusu.pb.requireProto('./test', require).grpc.testing.TestService;
+  var a = svc.serverApp;
   a.register('/grpc.testing.TestService/EmptyCall', emptyCall);
   a.register('/grpc.testing.TestService/UnaryCall', unaryCall);
   a.register('/grpc.testing.TestService/StreamingInputCall',

--- a/lib/app.js
+++ b/lib/app.js
@@ -40,7 +40,7 @@
 
 var _ = require('lodash');
 var dorusu = require('./dorusu');
-
+var client = require('./client');
 
 /**
  * A method describes an rpc that is to be available as part of a {Service}.
@@ -91,11 +91,12 @@ function Service(name, methods) {
 
 
 /**
- * RpcApp contains a number of `Services`, allowing them to deployed together on
- * a server.
+ * RpcApp contains a number of `Services`, allowing them to deployed together
+ * on a server.
  *
- * Its provides methods for registering handlers for the services, and obtaining
- * the handlers, marshallers and unmarshallers associate with registered routes.
+ * Its provides methods for registering handlers for the services, and
+ * obtaining the handlers, marshallers and unmarshallers associate with
+ * registered routes.
  *
  * @param {Services} services can be included when the RpcApp is constructed.
  * @constructor
@@ -108,6 +109,65 @@ function RpcApp() {
   this._services = {};
   _.each(arguments, this.addService.bind(this));
 }
+
+/**
+ * generates a client constructor from a service definition.
+ *
+ * @param {Service} service the service from which to generate the client.
+ * @returns {function} a constructor for a client to be used to access service.
+ */
+exports.buildClient = function buildClient(service) {
+  /**
+   * Defines a client class the has methods corresponding to each method in
+   * service.
+   *
+   * By default, connections from a Client are secure.
+   *
+   * @constructor
+   */
+  var Client = function Client(options) {
+    options = client.normalizeOptions(options);
+    options.serviceName = service.name;
+    this.stub = new client.RpcClient(options);
+  };
+
+  _.forEach(service.methods, function(m) {
+    var route = '/' + service.name + '/' + m.name;
+
+    /**
+     * @param {Object|external:Readable} src either the message to send or a
+     *                                       Readable giving a series of them
+     * @param {Object} headers sent along wih the message(s)
+     * @param {Object} opts holds optional info affecting the rpc
+     * @param {Object} opts.headers holds the rpc headers
+     * @param {function} callback a node-js callback called with the response.
+     */
+    var method = function method(src, callback, opts) {
+      var f = this.stub.rpcFunc(m.marshaller, m.unmarshaller);
+      return f(route, src, callback, opts);
+    };
+    Client.prototype[_.camelCase(m.name)] = method;
+  });
+
+  /**
+   * Defines a client class the has methods corresponding to each method in
+   * service.
+   *
+   * Connections from a RawClient are alway insecure.
+   *
+   * @constructor
+   */
+  var RawClient = function RawClient(options) {
+    options.plain = false;
+    Client.call(this, options);
+  };
+  RawClient.prototype = Object.create(Client.prototype, {
+    constructor: { value: RawClient }
+  });
+  Client.raw = RawClient;
+
+  return Client;
+};
 
 /**
  * Adds a service description.

--- a/lib/client.js
+++ b/lib/client.js
@@ -79,63 +79,24 @@ var Readable = require('stream').Readable;
 // [2]: http://nodejs.org/api/http.html
 // [3]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-8.1.2.4
 
-exports.Stub = Stub;
+exports.Stub = RpcClient;  /* Stub is an alias for RpcClient */
+exports.RpcClient = RpcClient;
 exports.EncodedOutgoingRequest = EncodedOutgoingRequest;
 exports.DecodedIncomingResponse = DecodedIncomingResponse;
 exports.Agent = Agent;
+exports.normalizeOptions = normalizeOptions;
 exports.globalAgent = undefined;
 
 /**
- * generates a client constructor from a service definition.
+ * RpcClient is the dorusu client endpoint for rpc connections.
  *
- * @param {Service} service the service from which to generate the client.
- * @returns {function} a constructor for a client to be used to access service.
- */
-exports.buildClient = function buildClient(service) {
-  /**
-   * Defines a client class the has methods corresponding to each method in
-   * service.
-   * @constructor
-   */
-  var svcClient = function svcClient(options) {
-    options = normalizeOptions(options);
-    options.serviceName = service.name;
-    this.stub = new Stub(options);
-  };
-  svcClient.prototype = Object.create(null, {
-    constructor: { value: svcClient }
-  });
-  _.forEach(service.methods, function(m) {
-    var route = '/' + service.name + '/' + m.name;
-
-    /**
-     * @param {Object|external:Readable} src either the message to send or a
-     *                                       Readable giving a series of them
-     * @param {Object} headers sent along wih the message(s)
-     * @param {Object} opts holds optional info affecting the rpc
-     * @param {Object} opts.headers holds the rpc headers
-     * @param {function} callback a node-js callback called with the response.
-     */
-    var method = function method(src, callback, opts) {
-      var f = this.stub.rpcFunc(m.marshaller, m.unmarshaller);
-      return f(route, src, callback, opts);
-    };
-    svcClient.prototype[_.camelCase(m.name)] = method;
-  });
-
-  return svcClient;
-};
-
-/**
- * Stub is the dorusu endpoint for rpc connections.
- *
- * @param {object} options for configuring the stub connection.  It expects
+ * @param {object} options for configuring the connection.  It expects
  *                 similar fields as are used to create a http.request.
  * @param {Agent} [option.agent] is used to establish the stub connection.
  * @param {Service} [option.service] is used to add additional funcs
  * @constructor
  */
-function Stub(options) {
+function RpcClient(options) {
   this.options = normalizeOptions(options);
   if (options.agent) {
     this.agent = options.agent;
@@ -145,9 +106,6 @@ function Stub(options) {
     this.agent = exports.globalAgent;
   }
 }
-Stub.prototype = Object.create(Object.prototype, {
-  constructor: { value: Stub }
-});
 
 /**
  * post is an rpc that expects a single request and provides a single response.
@@ -157,7 +115,7 @@ Stub.prototype = Object.create(Object.prototype, {
  * @param {function} callback a node callback to be called with response
  * @param {Object} headers additional information to send the server
  */
-Stub.prototype.post = function post(path, message, callback, headers) {
+RpcClient.prototype.post = function post(path, message, callback, headers) {
   var f = this.rpcFunc();
   return f(path, message, callback, headers);
 };
@@ -169,7 +127,7 @@ Stub.prototype.post = function post(path, message, callback, headers) {
  * @param {function} opt_unmarshal marshal any response
  * @return {function} a function that performs an rpc
  */
-Stub.prototype.rpcFunc = function rpcFunc(opt_marshal, opt_unmarshal) {
+RpcClient.prototype.rpcFunc = function rpcFunc(opt_marshal, opt_unmarshal) {
   /**
    * @param {string} path the path of the rpc at the rpc endpoint
    * @param {Object|external:Readable} msgSrc either the message or Readable
@@ -184,7 +142,7 @@ Stub.prototype.rpcFunc = function rpcFunc(opt_marshal, opt_unmarshal) {
       marshal: opt_marshal
     };
     _.merge(requestOpts, this.options, opts, function(a, b) {
-      /** Needed until lodash 4. is distributed
+      /** Needed until lodash 4 is distributed
        *
        * see https://github.com/lodash/lodash/issues/1453
        */

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@
 module.exports = require('./dorusu');
 module.exports.app = require('./app');
 module.exports.client = require('./client');
-module.exports.buildClient = module.exports.client.buildClient;
+module.exports.buildClient = module.exports.app.buildClient;
 module.exports.pb = require('./protobuf');
 module.exports.server = require('./server');
 module.exports.createServer = module.exports.server.createServer;

--- a/lib/protobuf.js
+++ b/lib/protobuf.js
@@ -147,12 +147,12 @@ var serverSideSvcFor = function serverSideSvcFor(protoSvc) {
  * they are converted into an object
  * {
  *   client: <client_service_peer>
- *   server: <server_service_peer>
+ *   server_app: app.RpcApp(<server_service_peer>)
  * }
  *
  * where client_service_peer can be used to create rpc clients using
- * `client.buildClient` and server_service_peer can be used specify services in
- * server apps via `app.RpcApp#addService`
+ * `client.buildClient`, and server_app is an app.RpcApp that can
+ * serve requests.
  *
  * @param {ProtoBuf.Reflect.Namespace} value the Protobuf object to load
  * @return {Object<string, *>} the peer object.
@@ -164,8 +164,8 @@ var loadObject = function loadObject(value) {
     return result;
   } else if (value.className === 'Service') {
     return {
-      client: clientSideSvcFor(value),
-      server: serverSideSvcFor(value)
+      Client: app.buildClient(clientSideSvcFor(value)),
+      serverApp: new app.RpcApp(serverSideSvcFor(value))
     };
   } else if (value.className === 'Message' || value.className === 'Enum') {
     return value.build();

--- a/test/client.js
+++ b/test/client.js
@@ -34,7 +34,6 @@
 
 var _ = require('lodash');
 var app = require('../lib/app');
-var buildClient = require('../lib/client').buildClient;
 var chai = require('chai');
 chai.use(require('dirty-chai'));
 var clientLog = require('./util').clientLog;
@@ -78,9 +77,9 @@ describe('Service Client', function() {
     app.Method('do_irreverse', null, reverser)
   ]);
   _.forEach(testOptions, function(serverOpts, connType) {
-    describe(connType + ': function `buildClient(service)`', function() {
+    describe(connType + ': function `app.buildClient(service)`', function() {
       it('should build a constructor that adds the expected methods', function() {
-        var Ctor = buildClient(testService);
+        var Ctor = app.buildClient(testService);
         expect(Ctor).to.be.a('function');
         var instance = new Ctor('http://localhost:8080/dummy/path');
         expect(instance.doEcho).to.be.a('function');
@@ -136,7 +135,7 @@ describe('Service Client', function() {
             decodeMessage(data, null, validateReqThenRespond);
           });
         };
-        var testClient = buildClient(testService);
+        var testClient = app.buildClient(testService);
         checkServiceClientAndServer(testClient, thisTest, thisServer, serverOpts);
       });
     });

--- a/test/go_external_interop_test.js
+++ b/test/go_external_interop_test.js
@@ -59,7 +59,7 @@ describe('External Interop Nodejs/Go', function() {
   this.timeout(8000);
 
   var testpb = dorusu.pb.requireProto('../interop/test');
-  var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
+  var TestServiceClient = testpb.grpc.testing.TestService.Client;
   var theClient, agent;
   _.forEach(testClientOptions, function(serverOpts, connType) {
     describe(connType, function() {
@@ -78,7 +78,11 @@ describe('External Interop Nodejs/Go', function() {
             family: 'IPv4'
           };
           _.merge(stubOpts, serverAddr, serverOpts);
-          theClient = new Ctor(stubOpts);
+          if (connType === 'secure') {
+            theClient = new TestServiceClient(stubOpts);
+          } else {
+            theClient = new TestServiceClient.raw(stubOpts);
+          }
           done();
         };
         makeGoServer(serverOpts, setUpClient);

--- a/test/interop_client_test.js
+++ b/test/interop_client_test.js
@@ -55,7 +55,7 @@ var testOptions = {
 describe('Interop Client', function() {
   var testpb = dorusu.pb.requireProto('../interop/test');
 
-  var Ctor = dorusu.buildClient(testpb.grpc.testing.TestService.client);
+  var TestServiceClient = testpb.grpc.testing.TestService.Client;
   var theClient, server, serverAddr;
   _.forEach(testOptions, function(serverOpts, connType) {
     describe(connType, function() {
@@ -66,7 +66,11 @@ describe('Interop Client', function() {
         listenOnFreePort(server, function(addr) {
           serverAddr = addr;
           _.merge(stubOpts, serverAddr, serverOpts);
-          theClient = new Ctor(stubOpts);
+          if (connType === 'secure') {
+            theClient = new TestServiceClient(stubOpts);
+          } else {
+            theClient = new TestServiceClient.raw(stubOpts);
+          }
           done();
         });
       });

--- a/test/math_client_test.js
+++ b/test/math_client_test.js
@@ -46,7 +46,7 @@ var secureOptions = require('../example/certs').options;
 http2.globalAgent = new http2.Agent({ log: clientLog });
 
 var mathpb = dorusu.pb.requireProto('../example/math');
-var mathClientCls = dorusu.buildClient(mathpb.math.Math.client);
+var MathClient = mathpb.math.Math.Client;
 var testOptions = {
   secure: secureOptions,
   insecure: insecureOptions
@@ -63,7 +63,11 @@ describe('Math Client', function() {
         listenOnFreePort(server, function(addr) {
           serverAddr = addr;
           _.merge(stubOpts, serverAddr, serverOpts);
-          client = new mathClientCls(stubOpts);
+          if (connType === 'secure') {
+            client = new MathClient(stubOpts);
+          } else {
+            client = new MathClient.raw(stubOpts);
+          }
           done();
         });
       });


### PR DESCRIPTION
- Make protobuf create server and client instances directly
- Add a raw client constructor

(to be submitted after #18)
#### Make protobuf create server and client instances directly
- protobuf.{require,load}Proto is modified so that for parsed services
  - `<package>.client` => `<package>.Client`
    - where <package>.Client is a client constructor class
  - `<package>.server` => `<package>.serverApp`
    - where <package>.serverApp is an app.RpcApp that specifies a service to be implemented.
#### Add a raw client constructor
- Adds '.raw' property to the client constructors, which is always an
  equivalent constructor whose instances are always insecure.
- refactoring 'client.buildClient' => 'app.buildClient'
