### PR TITLE
Add an npm command for the prod interop tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
 node_modules
+npm-debug.log
 coverage
 docs

--- a/README.md
+++ b/README.md
@@ -232,15 +232,38 @@ npm test
 ```
 
 ### interop tests
-```bash
-npm run interop-test
-```
+
 _Note_ The node interop test client is tested against the node interop test server as part of the [unit tests](#unit_tests).   `interop-test` here actual runs against [grpc-go][].
 
 - the test is skipped unless Go is installed.
 - when Go is available, the test installs [grpc-go][] to a temporary location and runs the interop client against the grpc-go server and vice versa.
 
+```bash
+# Install the Go interop test server and client to a temporary location
+npm run install-go-interop
+
+# Run the interop tests
+npm run interop-test
+```
+
 [grpc-go]:https://github.com/grpc/grpc-go
+
+### production interop tests
+
+- without [bunyan][] installed
+```bash
+npm run prod-interop
+
+```
+
+- without [bunyan][] installed (the logs are nicely formatted)
+```bash
+npm run bunyan-prod-interop
+
+```
+
+[grpc-go]:https://github.com/grpc/grpc-go
+
 
 ## CONTRIBUTING/REPORTING ISSUES
 

--- a/interop/interop_client.js
+++ b/interop/interop_client.js
@@ -75,9 +75,6 @@ var ArgumentParser = require('argparse').ArgumentParser;
 var Readable = require('stream').Readable;
 var PassThrough = require('stream').PassThrough;
 
-// Setup functions to use the default (noop) logger; main() resets this.
-var log = dorusu.noopLogger;
-
 /**
  * Create a buffer filled with `size` zeroes.
  *
@@ -136,9 +133,10 @@ exports.emptyUnary = function emptyUnary(client, next) {
   var req = {};
   var onEnd = function() {
     expect(gotMsg).to.eql({});
-    log.info('Verified: ok emptyCall(', req, ') =>', gotMsg);
+    dorusu.logger.info('Verified: ok emptyCall(', req, ') =>', gotMsg);
     next();
   };
+  dorusu.logger.info('Checking: emptyCall');
   client.emptyCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -153,7 +151,7 @@ exports.largeUnary = function largeUnary(client, next) {
   var onEnd = function() {
     expect(gotMsg.payload.type).to.eql('COMPRESSABLE');
     expect(gotMsg.payload.body.length).to.eql(314159);
-    log.info('Verified: largeUnary(...) => (', gotMsg, ')');
+    dorusu.logger.info('Verified: largeUnary(...) => (', gotMsg, ')');
     next();
   };
 
@@ -165,6 +163,7 @@ exports.largeUnary = function largeUnary(client, next) {
       body: zeroes(271828)
     }
   };
+  dorusu.logger.info('Checking: largeUnary');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -196,7 +195,7 @@ exports.computeEngine = function computeEngine(Ctor, opts, args, next) {
     expect(gotMsg.payload.type).to.eql('COMPRESSABLE');
     expect(gotMsg.payload.body.length).to.eql(314159);
     expect(gotMsg.username).to.eql(wantedEmail);
-    log.info('Verified: computeEngine had email %s', wantedEmail);
+    dorusu.logger.info('Verified: computeEngine had email %s', wantedEmail);
     next();
   };
 
@@ -212,6 +211,7 @@ exports.computeEngine = function computeEngine(Ctor, opts, args, next) {
   };
   opts.updateHeaders = dorusu.addAuthFromADC();  // no scope needed on GCE
   var client = new Ctor(opts);
+  dorusu.logger.info('Checking: computeEngine');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -232,7 +232,7 @@ exports.jwtTokenCreds = function jwtTokenCreds(Ctor, opts, args, next) {
       expect(gotMsg.payload.type).to.eql('COMPRESSABLE');
       expect(gotMsg.payload.body.length).to.eql(314159);
       expect(gotMsg.username).to.eql(wantedEmail);
-      log.info('Verified: jwtTokenCreds had email %s', gotMsg.username);
+      dorusu.logger.info('Verified: jwtTokenCreds had email %s', gotMsg.username);
       next();
     });
   };
@@ -249,6 +249,7 @@ exports.jwtTokenCreds = function jwtTokenCreds(Ctor, opts, args, next) {
     response_size: 314159,
     response_type: 'COMPRESSABLE'
   };
+  dorusu.logger.info('Checking: jwtTokens');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -271,7 +272,7 @@ exports.oauth2AuthToken = function oauth2AuthToken(Ctor, opts, args, next) {
       expect(gotMsg.oauth_scope).to.not.be.empty();
       expect(args.oauth_scope).to.have.string(gotMsg.oauth_scope);
       expect(gotMsg.username).to.eql(wantedEmail);
-      log.info('Verified: oauth2AuthToken had scope %s', gotMsg.oauth_scope);
+      dorusu.logger.info('Verified: oauth2AuthToken had scope %s', gotMsg.oauth_scope);
       next();
     });
   };
@@ -288,6 +289,7 @@ exports.oauth2AuthToken = function oauth2AuthToken(Ctor, opts, args, next) {
     response_size: 314159,
     response_type: 'COMPRESSABLE'
   };
+  dorusu.logger.info('Checking: oauth2AuthToken');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -317,7 +319,7 @@ exports.perRpcCreds = function perRpcCreds(Ctor, opts, args, next) {
       expect(gotMsg.oauth_scope).to.not.be.empty();
       expect(args.oauth_scope).to.have.string(gotMsg.oauth_scope);
       expect(gotMsg.username).to.eql(wantedEmail);
-      log.info('Verified: perRpcCreds had scope %s', gotMsg.oauth_scope);
+      dorusu.logger.info('Verified: perRpcCreds had scope %s', gotMsg.oauth_scope);
     });
     next();
   };
@@ -333,6 +335,7 @@ exports.perRpcCreds = function perRpcCreds(Ctor, opts, args, next) {
     response_size: 314159,
     response_type: 'COMPRESSABLE'
   };
+  dorusu.logger.info('Checking: perRpcCreds');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -357,7 +360,7 @@ exports.serviceAccount = function serviceAccount(Ctor, opts, args, next) {
       expect(gotMsg.oauth_scope).to.not.be.empty();
       expect(args.oauth_scope).to.have.string(gotMsg.oauth_scope);
       expect(gotMsg.username).to.eql(wantedEmail);
-      log.info('Verified: serviceAccountCreds had scope %s', gotMsg.oauth_scope);
+      dorusu.logger.info('Verified: serviceAccountCreds had scope %s', gotMsg.oauth_scope);
       next();
     });
   };
@@ -374,6 +377,7 @@ exports.serviceAccount = function serviceAccount(Ctor, opts, args, next) {
     response_size: 314159,
     response_type: 'COMPRESSABLE'
   };
+  dorusu.logger.info('Checking: serviceAccount');
   client.unaryCall(req, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -388,7 +392,7 @@ exports.clientStreaming = function clientStreaming(client, next) {
   };
   var onEnd = function onEnd() {
     expect(gotMsg.aggregated_payload_size).to.eql(74922);
-    log.info('Verified: OK, clientStreaming sent 74922 bytes');
+    dorusu.logger.info('Verified: OK, clientStreaming sent 74922 bytes');
     done();
   };
 
@@ -399,6 +403,7 @@ exports.clientStreaming = function clientStreaming(client, next) {
     src.push({payload: {body: zeroes(payloadSizes[i])}});
   }
   src.push(null);
+  dorusu.logger.info('Checking: clientStreaming');
   client.streamingInputCall(src, function(response) {
     response.on('end', onEnd);
     response.on('data', saveMessage);
@@ -410,12 +415,13 @@ exports.cancelAfterBegin = function cancelAfterBegin(client, next) {
   var verifyWasCancelled = function verifyWasCancelled(code) {
     var wantedCode = dorusu.rpcCode('CANCELLED');
     expect(code).to.equal(wantedCode);
-    log.info('Verified: OK, cancelAfterBegin had cancelled OK');
+    dorusu.logger.info('Verified: OK, cancelAfterBegin had cancelled OK');
     done();
   };
 
   // Run the test.
   var src = new PassThrough({objectMode: true});
+  dorusu.logger.info('Checking: cancelAfterBegin');
   var req = client.streamingInputCall(src, _.noop);
   req.on('cancel', verifyWasCancelled);
   req.cancel();
@@ -428,10 +434,10 @@ exports.cancelAfterFirst = function cancelAfterFirst(client, next) {
   var index = 0;
   var nextPing = function nextPing() {
     if (index === 4) {
-      log.info('cancelAfterFirst: ending after', index, 'pings');
+      dorusu.logger.info('cancelAfterFirst: ending after', index, 'pings');
       src.end();
     } else {
-      log.info('cancelAfterFirst: writing index:', index);
+      dorusu.logger.info('cancelAfterFirst: writing message #', index);
       src.write({
         response_type: 'COMPRESSABLE',
         response_parameters: [
@@ -444,12 +450,12 @@ exports.cancelAfterFirst = function cancelAfterFirst(client, next) {
   var cancelled = false;
   var req;
   var verifyEachMessage = function verifyEachMessage(msg) {
-    log.info('cancelAfterFirst: receiving index:', index);
+    dorusu.logger.info('cancelAfterFirst: receiving index:', index);
     expect(msg.payload.type).to.eql('COMPRESSABLE');
     expect(msg.payload.body.lengh, responseSizes[index]);
     index += 1;
     if (index === 1 && req) {
-      log.info('... cancelling after', index, 'msg');
+      dorusu.logger.info('... cancelling after', index, 'msg');
       req.cancel();
     }
     nextPing();
@@ -457,12 +463,13 @@ exports.cancelAfterFirst = function cancelAfterFirst(client, next) {
   var done = next || _.noop;
   var onEnd = function onEnd() {
     expect(cancelled).to.be.true();
-    log.info('Verified: cancelAfterFirst cancelled after', index, 'msg');
+    dorusu.logger.info('Verified: cancelAfterFirst cancelled after', index, 'msg');
     done();
   };
 
   // Run the test.
   nextPing();  // start with a ping
+  dorusu.logger.info('Checking: cancelAfterFirst');
   req = client.fullDuplexCall(src, function onResponse(response) {
     response.on('data', verifyEachMessage);
     response.on('end', onEnd);
@@ -480,10 +487,10 @@ exports.timeoutOnSleeper = function timeoutOnSleeper(client, next) {
   var index = 0;
   var nextPing = function nextPing() {
     if (index === 4) {
-      log.info('timeoutOnSleeper: ending after', index, 'pings');
+      dorusu.logger.info('timeoutOnSleeper: ending after', index, 'pings');
       src.end();
     } else {
-      log.info('timeoutOnSleeper: writing index:', index);
+      dorusu.logger.info('timeoutOnSleeper: writing message #', index);
       src.write({
         response_type: 'COMPRESSABLE',
         response_parameters: [
@@ -494,7 +501,7 @@ exports.timeoutOnSleeper = function timeoutOnSleeper(client, next) {
     }
   };
   var verifyEachMessage = function verifyEachMessage(msg) {
-    log.info('timeoutOnSleeper: receiving index:', index);
+    dorusu.logger.info('timeoutOnSleeper: receiving index:', index);
     expect(msg.payload.type).to.eql('COMPRESSABLE');
     expect(msg.payload.body.lengh, responseSizes[index]);
     index += 1;
@@ -502,12 +509,13 @@ exports.timeoutOnSleeper = function timeoutOnSleeper(client, next) {
   };
   var verifyCancelled = function() {
     expect(index).to.be.below(payloadSizes.length);
-    log.info('Verified: timeoutOnSleeper cancelled after', index, 'msg');
+    dorusu.logger.info('Verified: timeoutOnSleeper cancelled after', index, 'msg');
     done();
   };
 
   // Run the test.
   nextPing();  // start with a ping
+  dorusu.logger.info('Checking: timeoutOnSleeper');
   var req = client.fullDuplexCall(src, function onResponse(response) {
     response.on('data', verifyEachMessage);
   }, {
@@ -538,9 +546,10 @@ exports.serverStreaming = function serverStreaming(client, next) {
   };
 
   // Run the test.
+  dorusu.logger.info('Checking: serverStreaming');
   client.streamingOutputCall(req, function(response) {
     response.on('end', function() {
-      log.info('Verified: streamingStreaming received', index, 'msgs');
+      dorusu.logger.info('Verified: streamingStreaming received', index, 'msgs');
       done();
     });
     response.on('data', verifyEachMessage);
@@ -555,10 +564,10 @@ exports.pingPong = function pingPong(client, next) {
   var index = 0;
   var nextPing = function nextPing() {
     if (index === 4) {
-      log.info('pingPong: ending after', index, 'pings');
+      dorusu.logger.info('pingPong: ending after', index, 'pings');
       src.end();
     } else {
-      log.info('pingPong: writing index:', index);
+      dorusu.logger.info('pingPong: writing message #', index);
       src.write({
         response_type: 'COMPRESSABLE',
         response_parameters: [
@@ -569,7 +578,7 @@ exports.pingPong = function pingPong(client, next) {
     }
   };
   var verifyEachMessage = function verifyEachMessage(msg) {
-    log.info('pingPong: receiving index:', index);
+    dorusu.logger.info('pingPong: receiving index:', index);
     expect(msg.payload.type).to.eql('COMPRESSABLE');
     expect(msg.payload.body.lengh, responseSizes[index]);
     index += 1;
@@ -578,9 +587,10 @@ exports.pingPong = function pingPong(client, next) {
 
   // Run the test.
   nextPing();  // start with a ping
+  dorusu.logger.info('Checking: pingPong');
   client.fullDuplexCall(src, function(response) {
     response.on('end', function() {
-      log.info('Verified: pingPong sent/received', index, 'msgs');
+      dorusu.logger.info('Verified: pingPong sent/received', index, 'msgs');
       done();
     });
     response.on('data', verifyEachMessage);
@@ -591,9 +601,10 @@ exports.emptyStream = function emptyStream(client, next) {
   var done = next || _.noop;
   var src = new Readable({objectMode:true});
   src.push(null);  // Do not send any messages;
+  dorusu.logger.info('Checking: emptyStream');
   client.fullDuplexCall(src, function(response) {
     response.on('end', function() {
-      log.info('Verified: empty stream sent/received');
+      dorusu.logger.info('Verified: empty stream sent/received');
       done();
     });
     response.on('data', function() {
@@ -633,9 +644,9 @@ exports.withoutAuthTests = {
   empty_unary: exports.emptyUnary,
   client_streaming: exports.clientStreaming,
   server_streaming: exports.serverStreaming,
-  ping_pong: exports.pingPong,
   empty_stream: exports.emptyStream,
-  timeout_on_sleeping_server: exports.timeoutOnSleeper
+  timeout_on_sleeping_server: exports.timeoutOnSleeper,
+  ping_pong: exports.pingPong
 };
 
 /**
@@ -735,16 +746,16 @@ var parseArgs = function parseArgs() {
  * Provides the command line entry point when this file is run as a script.
  */
 var main = function main() {
-  log = bunyan.createLogger({
+  var log = bunyan.createLogger({
     name: 'interop_client',
     stream: process.stdout,
     level: process.env.HTTP2_LOG || 'info',
     serializers: http2.serializers
   });
+  dorusu.configure({logger: log});
 
   var args = parseArgs();
   var opts = {
-    log: log,
     port: args.server_port,
     host: args.server_host
   };

--- a/interop/run_prod_interop.js
+++ b/interop/run_prod_interop.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+'use strict';
+
+/**
+ * dorusu/interop/run_prod_interop use interop_client to run the standard
+ * prod interop tests
+ *
+ * @module dorusu/interop/run_prod_interop
+ */
+
+var async = require('async');
+var bunyan = require('bunyan');
+var dorusu = require('../lib');
+var http2 = require('http2');
+var interopClient = require('./interop_client');
+
+/**
+ * Provides the command line entry point when this file is run as a script.
+ */
+var main = function main() {
+  var log = bunyan.createLogger({
+    name: 'prod_interop',
+    stream: process.stdout,
+    level: process.env.HTTP2_LOG || 'info',
+    serializers: http2.serializers
+  });
+  dorusu.configure({logger: log});
+
+  // Run the test against the default sandbox
+  var testpb = dorusu.pb.requireProto('./test', require);
+  var TestServiceClient = testpb.grpc.testing.TestService.Client;
+  var client = new TestServiceClient({
+    log: log,
+    host: 'grpc-test.sandbox.googleapis.com'
+  });
+  async.series([
+    interopClient.withoutAuthTests.all.bind(null, client),
+    process.exit.bind(null, 0)  /* TODO enable client's to be closed */
+  ]);
+};
+
+if (require.main === module) {
+  main();
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -596,9 +596,9 @@ EncodedOutgoingRequest.prototype._start = function _start(stream, options) {
   }
 
   // Send the headers
-  this._log.info({ scheme: headers[':scheme'], method: headers[':method'],
-                   authority: headers[':authority'], path: headers[':path'],
-                   headers: (options.headers || {}) }, 'Sending request');
+  this._log.debug({ scheme: headers[':scheme'], method: headers[':method'],
+                    authority: headers[':authority'], path: headers[':path'],
+                    headers: (headers || {}) }, 'Sending request');
   this.stream.headers(headers);
   this.headersSent = true;
 
@@ -607,7 +607,7 @@ EncodedOutgoingRequest.prototype._start = function _start(stream, options) {
 
   // Create the response, once it's ready have it fire the request's response
   // handler
-  var response = new DecodedIncomingResponse(this.stream, this.codecOpts);
+  var response = new DecodedIncomingResponse(stream, this.codecOpts);
   this.cancelResponse = response.canceller;
   response.once('ready', this.emit.bind(this, 'response', response));
 };
@@ -724,6 +724,19 @@ DecodedIncomingResponse.prototype.on = function on(event, listener) {
 };
 
 /**
+ * Hack for accessing Google-servers, which return a 'connection' header in their responses.
+ *
+ * TODO: check to see whether this is permitted by the spec.  If not, leave this hack until
+ * Google fix their servers.  Otherwise, fix in node-http2
+ */
+DecodedIncomingResponse.prototype._validateHeaders = function _validateHeaders(headers) {
+  if (headers.connection) {
+    delete headers.connection;
+  }
+  IncomingResponse.prototype._validateHeaders.call(this, headers);
+};
+
+/**
  * Extends `IncomingResponse._onHeaders` to handle the rpc protocols' special
  * status headers.
  *
@@ -804,7 +817,7 @@ DecodedIncomingResponse.prototype._cancel = function _cancel(code) {
  * assigned when it ends.
  */
 DecodedIncomingResponse.prototype._checkOnEnd = function _checkOnEnd() {
-  this._log.info('stream on <end>, rpcStatus is %j', this._rpcStatus);
+  this._log.debug('stream on <end>, rpcStatus is %j', this._rpcStatus);
   if (!this._rpcStatus) {
     throw new Error('No rpc status was received');
   }

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -58,7 +58,7 @@ exports.encodeMessage = function encodeMessage(message, opts, done) {
   // TODO: the highWaterMark should be configurable, get it from opts.
   var s = new Readable({highWaterMark: 32 * 1024 * 1024});
   opts = opts || {};
-  var log = (opts.log || dorusu.noopLogger).child({ component: 'codec' });
+  var log = (opts.log || dorusu.logger).child({ component: 'codec' });
   if (opts.marshal) {
     try {
       s.push(opts.marshal(message));
@@ -95,7 +95,7 @@ exports.EncodingStream = EncodingStream;
  */
 function EncodingStream(opts) {
   this.opts = opts = opts || {};   // ensure opts is an object
-  this._log = (opts.log || dorusu.noopLogger).child({ component: 'codec' });
+  this._log = (opts.log || dorusu.logger).child({ component: 'codec' });
 
   opts.writableObjectMode = true;  // the messages are objects
   this._marshal = opts.marshal;
@@ -152,7 +152,7 @@ var COMPRESSION_INDEX = 0;
 exports.decodeMessage = function decodeMessage(encoded, opts, done) {
   opts = opts || {};
   var buf = new Buffer(encoded);
-  var log = (opts.log || dorusu.noopLogger).child({ component: 'codec' });
+  var log = (opts.log || dorusu.logger).child({ component: 'codec' });
   if (buf.length < MINIMUM_ENCODED_LENGTH) {
     log.error('Encoded message was smaller than ' + MINIMUM_ENCODED_LENGTH);
     done(new RangeError(
@@ -198,7 +198,7 @@ exports.DecodingStream = DecodingStream;
  */
 function DecodingStream(opts) {
   this.opts = opts = opts || {}; // ensure opts is an object
-  this._log = (opts.log || dorusu.noopLogger).child({ component: 'codec' });
+  this._log = (opts.log || dorusu.logger).child({ component: 'codec' });
   opts.readableObjectMode = true; // Buffers will read from this stream
   Transform.call(this, opts);
 
@@ -416,8 +416,7 @@ exports.microsToInterval = function microsToInterval(micros) {
   if (res) {
     return res;
   }
-  var log = dorusu.noopLogger;
-  log.error('interval encode failed: could not encode ', micros);
+  dorusu.logger.error('interval encode failed: could not encode ', micros);
   throw new RangeError('interval encode failed');
 };
 
@@ -433,8 +432,7 @@ var intervalRx = /^(\d+)(H|M|S|m|u|n)$/;
 exports.intervalToMicros = function intervalToMicros(interval) {
   var parsed = interval.match(intervalRx);
   if (!parsed) {
-    var log = dorusu.noopLogger;
-    log.error('interval decode failed: could not encode ', interval);
+    dorusu.logger.error('interval decode failed: could not encode ', interval);
     throw new RangeError('interval decode failed');
   }
   var amt = parseInt(parsed[1], 10);

--- a/lib/dorusu.js
+++ b/lib/dorusu.js
@@ -116,6 +116,9 @@ exports.configure = function configure(opts) {
   if (opts.secureHeaderPolicy) {
     exports.secureHeaderPolicy = opts.secureHeaderPolicy;
   }
+  if (opts.logger) {
+    exports.logger = opts.logger;
+  }
 };
 
 /**
@@ -510,6 +513,7 @@ var noopLogger = {
   child: function() { return this; }
 };
 
+exports.logger = noopLogger;
 exports.noopLogger = noopLogger;
 exports.reservedHeaders = reservedHeaders;
 exports.rpcCodes = rpcCodes;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "codecov": "istanbul cover -x '**/example/**' -x '**/interop/**' _mocha -- --full-trace --reporter spec -i -g 'External Interop' --slow 1000 --timeout 5000 && codecov",
     "doc": "jsdoc -c jsdoc.json",
     "interop-test": "istanbul test _mocha -- --reporter spec -g 'External Interop'",
+    "prod-interop": "./interop/run_prod_interop.js",
+    "bunyan-prod-interop": "./interop/run_prod_interop.js | bunyan -o short",
     "install-go-interop": "./interop/go_interop_agent.js",
     "lint": "jshint lib test interop example",
     "preversion": "npm test && npm run lint",


### PR DESCRIPTION
- Adds a script that just runs the interop tests against a prod server
- Adds a npm command that runs the script: npm run prod-interop
- Updates the README.md to describe how to use the command

Also:
- enables the global logger to be configured using dorusu.configure
- adds a hack to response handling to ignore the fact that the response
  from Google server's contains a deprecated header ('connection')
