### PR TITLE
Track the latest changes in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Changes
+
+* Add a command for running the prod interop tests ([@tbetbetbe][])
+* Add server child requests ([@tbetbetbe][])
+* Allow the timeout to be specified using a Date() instance ([@tbetbetbe][])
+* Correct error-handling to produce status codes that match [the status code spec](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) ([@tbetbetbe][])
+
 ## 0.5.0 (2016/05/26)
 
 ### Changes


### PR DESCRIPTION
- in future, any significant changes should include an update to the
  CHANGELOG
